### PR TITLE
fix(45): limit DNS requests when running in container

### DIFF
--- a/src/api_client.py
+++ b/src/api_client.py
@@ -25,6 +25,7 @@ class ApiClient:
 
     def __post_init__(self):
         self._auth_header = {}
+        self._session = requests.Session()
 
     @property
     def request_url(self):
@@ -43,7 +44,7 @@ class ApiClient:
         return self._auth_header
 
     def _create_auth_header(self):
-        res = requests.post(
+        res = self._session.post(
             self.authentication_url,
             data={
                 "username": self.username,
@@ -68,11 +69,11 @@ class ApiClient:
         return {"Authorization": f"Bearer {token}"}
 
     def send_sync_reading(self, reading: SensorReading) -> bool:
-        res = requests.post(self.request_url, headers=self.get_auth_header(), json=reading.serialize(), timeout=10)
+        res = self._session.post(self.request_url, headers=self.get_auth_header(), json=reading.serialize(), timeout=10)
         if res.status_code == 200:
             return True
         if res.status_code == 401:
-            res = requests.post(
+            res = self._session.post(
                 self.request_url, headers=self.get_auth_header(refresh=True), json=reading.serialize(), timeout=10
             )
         else:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -78,7 +78,7 @@ def test_init_from_config(api_config, api_client):
         ),
     ],
 )
-@unittest.mock.patch("requests.post")
+@unittest.mock.patch("requests.Session.post")
 def test_create_auth_header_valid_password(mock_auth_response, auth_response, token, api_client):
     mock_res = lambda: None
     mock_res.text = auth_response
@@ -90,7 +90,7 @@ def test_create_auth_header_valid_password(mock_auth_response, auth_response, to
     assert actual_auth_header == {"Authorization": f"Bearer {token}"}
 
 
-@unittest.mock.patch("requests.post")
+@unittest.mock.patch("requests.Session.post")
 def test_create_auth_header_empty_password(mock_auth_response, api_client):
     mock_res = lambda: None
     mock_res.status_code = 422
@@ -102,7 +102,7 @@ def test_create_auth_header_empty_password(mock_auth_response, api_client):
     assert str(e.value) == "Non-empty password must be provided."
 
 
-@unittest.mock.patch("requests.post")
+@unittest.mock.patch("requests.Session.post")
 def test_create_auth_header_wrong_password(mock_auth_response, api_client):
     mock_res = lambda: None
     mock_res.status_code = 401
@@ -114,7 +114,7 @@ def test_create_auth_header_wrong_password(mock_auth_response, api_client):
     assert str(e.value) == "Username or password is incorrect."
 
 
-@unittest.mock.patch("requests.post")
+@unittest.mock.patch("requests.Session.post")
 def test_create_auth_header_other_error(mock_auth_response, api_client):
     mock_res = lambda: None
     mock_res.status_code = 404
@@ -142,7 +142,7 @@ def test_get_auth_header(api_client, auth_header):
         (401, False),  # Invalid token
     ],
 )
-@unittest.mock.patch("requests.post")
+@unittest.mock.patch("requests.Session.post")
 def test_send_sync_reading(mock_auth_response, status_code, return_value, api_client, auth_header, sensor_reading):
     mock_res = lambda: None
     mock_res.status_code = status_code


### PR DESCRIPTION
- add session handling to keep connection alive. This naturally limits DNS requests even if no DNS caching is active